### PR TITLE
Correction to Config::get call for loading API key from bundle config

### DIFF
--- a/libraries/mandrill.php
+++ b/libraries/mandrill.php
@@ -17,7 +17,7 @@ class Mandrill
 	{
 
 		// load api key
-		$api_key = Config::get('mandrill.api_key');
+		$api_key = Config::get('mandrill::mandrill.api_key');
 		
 		// determine endpoint
 		$endpoint = 'https://mandrillapp.com/api/1.0/'.$method.'.json';
@@ -33,6 +33,7 @@ class Mandrill
 		curl_setopt($ch, CURLOPT_SSL_VERIFYHOST, true);
 		curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, true);
 		curl_setopt($ch, CURLOPT_POST, true);
+		curl_setopt($ch, CURLOPT_HTTPHEADER, array('Content-Type: application/json'));
 		curl_setopt($ch, CURLOPT_POSTFIELDS, json_encode($arguments));
 		$response = curl_exec($ch);
 


### PR DESCRIPTION
The application I was using your bundle in consistently failed to call the Mandrill API correctly, returning "Invalid key" messages.

I eventually tracked this down to the fact that API key wasn't being loaded from the bundle config file.

There needs to be an extra "mandrill::" inside the Config::get call to access the Mandrill bundle namespace.

All fixed now. Thanks for the bundle! :-)

Cheers,
Drew Robinson
