### PR TITLE
Simple typo fix in readme.md

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,7 +1,7 @@
 # Mandrill for LaravelPHP #
 
 This package is a simple wrapper for working w/ the [Mandrill API](http://mandrillapp.com/api/docs/).
-The code of the application is based on Scott Travis' [Mailchimp Bunle](https://github.com/swt83/laravel-mailchimp).
+The code of the application is based on Scott Travis' [Mailchimp Bundle](https://github.com/swt83/laravel-mailchimp).
 
 ## Install ##
 


### PR DESCRIPTION
Replaced "bunle" with "bundle".
