### PR TITLE
Fixing CURLOPT_SSL_VERIFY_HOST

### DIFF
--- a/libraries/mandrill.php
+++ b/libraries/mandrill.php
@@ -30,7 +30,7 @@ class Mandrill
 		curl_setopt($ch, CURLOPT_URL, $endpoint);
 		curl_setopt($ch, CURLOPT_TIMEOUT, 30);
 		curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
-		curl_setopt($ch, CURLOPT_SSL_VERIFYHOST, true);
+		curl_setopt($ch, CURLOPT_SSL_VERIFYHOST, 2);
 		curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, true);
 		curl_setopt($ch, CURLOPT_POST, true);
 		curl_setopt($ch, CURLOPT_HTTPHEADER, array('Content-Type: application/json'));


### PR DESCRIPTION
According to PHP's documentation, that option accepts integer values and not boolean.

> 1 to check the existence of a common name in the SSL peer certificate. 2 to check the existence of a common name and also verify that it matches the hostname provided. In production environments the value of this option should be kept at 2 (default value).

http://php.net/manual/en/function.curl-setopt.php

Recently, libcurl entirely removed support for 1 and this causes errors on Laravel. More info on:
https://bugs.php.net/bug.php?id=63795
http://www.serverphorums.com/read.php?7,620892
